### PR TITLE
fix: client side request url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # server settings
-API_HOST=http://localhost:3000
+HOST=0.0.0.0
+PORT=3000
 
 # postgres settings
 DATABASE_HOST=localhost

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ COPY . /usr/src
 # install dependencies
 RUN npm install
 
-
 # start app
 RUN npm run build
-EXPOSE 3000
 CMD npm run express

--- a/components/link/create.js
+++ b/components/link/create.js
@@ -7,7 +7,6 @@ import Grid from '@material-ui/core/Grid'
 import { makeStyles } from '@material-ui/core/styles'
 
 const randwords = randomWords(100)
-const host = process.env.API_HOST
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -36,6 +35,8 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 export default function CreateLink(props) {
+  const baseUrl = window.location.origin
+
   const classes = useStyles()
   const [values, setValues] = React.useState({
     name: '',
@@ -58,7 +59,7 @@ export default function CreateLink(props) {
       r = r.replace(reg, words[idx])
     })
     return {
-      link: process.env.API_HOST + '/' + values.name + '/' + words.join('/'),
+      link: baseUrl + '/' + values.name + '/' + words.join('/'),
       regex: r,
     }
   }
@@ -112,7 +113,7 @@ export default function CreateLink(props) {
             <Paper className={classes.paper}>
               <h3>How Your Link Will Work</h3>
               <p className={classes.p}>
-                {host}/{values.name} will redirect to {values.destination}
+                {baseUrl}/{values.name} will redirect to {values.destination}
               </p>
 
               {values.regex_destination && (

--- a/components/link/edit.js
+++ b/components/link/edit.js
@@ -9,7 +9,6 @@ import DeleteIcon from '@material-ui/icons/Delete'
 import { makeStyles } from '@material-ui/core/styles'
 
 const randwords = randomWords(100)
-const host = process.env.API_HOST
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -44,6 +43,8 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 export default function EditLink(props) {
+  const baseUrl = window.location.origin
+
   const classes = useStyles()
   const link = props.link
   const [values, setValues] = React.useState({
@@ -70,7 +71,7 @@ export default function EditLink(props) {
       r = r.replace(reg, words[idx])
     })
     return {
-      link: process.env.API_HOST + '/' + values.name + '/' + words.join('/'),
+      link: baseUrl + '/' + values.name + '/' + words.join('/'),
       regex: r,
     }
   }
@@ -155,7 +156,7 @@ export default function EditLink(props) {
             <Paper className={classes.paper}>
               <h3>How Your Link Works</h3>
               <p className={classes.p}>
-                {host}/{values.name} will redirect to {values.destination}
+                {baseUrl}/{values.name} will redirect to {values.destination}
               </p>
 
               {values.regex_destination && (

--- a/lib/authed_fetch.js
+++ b/lib/authed_fetch.js
@@ -8,7 +8,9 @@ export default async function authedFetch(ctx, uri, options = {}) {
   const req = ctx.req
   const token = await jwt.getToken({ req, secret, raw: true })
   const bearer = 'Bearer ' + token
-  const url = process.env.API_HOST + uri
+  const host = process.env.HOST || "localhost";
+  const port = process.env.PORT || 3000;
+  const url = `http://${host}:${port}${uri}`
   const res = await fetch(url, {
     headers: { Authorization: bearer },
     method: method,

--- a/pages/[...path].js
+++ b/pages/[...path].js
@@ -61,6 +61,7 @@ export async function getServerSideProps(ctx) {
       },
     }
   } else {
+    ctx.res.statusCode = res.res.status
     return {
       props: {
         path: path,

--- a/pages/create.js
+++ b/pages/create.js
@@ -18,11 +18,10 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 export default function Create({ link, notFound, token }) {
-  const api_host = process.env.API_HOST
   const router = useRouter()
   const handleSubmit = (values) => (event) => {
     const bearer = 'Bearer ' + token
-    const url = api_host + '/api/links/' + values.name
+    const url = '/api/links/' + values.name
     const res = fetch(url, {
       headers: { Authorization: bearer, 'Content-Type': 'application/json' },
       method: 'POST',

--- a/pages/edit/[name].js
+++ b/pages/edit/[name].js
@@ -20,11 +20,10 @@ const useStyles = makeStyles((theme) => ({
 
 export default function Edit({ link, notFound, token, name, logs }) {
   const router = useRouter()
-  const api_host = process.env.API_HOST
 
   const handleSubmit = (values) => (event) => {
     const bearer = 'Bearer ' + token
-    const url = api_host + '/api/links/' + values.name
+    const url = '/api/links/' + values.name
     const res = fetch(url, {
       headers: { Authorization: bearer, 'Content-Type': 'application/json' },
       method: 'PUT',
@@ -43,7 +42,7 @@ export default function Edit({ link, notFound, token, name, logs }) {
 
   const handleDelete = (name) => (event) => {
     const bearer = 'Bearer ' + token
-    const url = api_host + '/api/links/' + name
+    const url = '/api/links/' + name
     const res = fetch(url, {
       headers: { Authorization: bearer, 'Content-Type': 'application/json' },
       method: 'DELETE',

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ const env = process.env.NODE_ENV || 'production';
 const dev = env !== "production";
 const app = next({ dev });
 const handle = app.getRequestHandler();
+const host = process.env.HOST || "0.0.0.0";
 const port = process.env.PORT || 3000;
 const promMid = require('express-prometheus-middleware');
 
@@ -23,9 +24,9 @@ const promMid = require('express-prometheus-middleware');
     server.all("*", (req, res) => {
       return handle(req, res);
     });
-    server.listen(port, (err) => {
+    server.listen(port, host, (err) => {
       if (err) throw err;
-      console.log(`> Ready on localhost:${port} - env ${env}`);
+      console.log(`> Ready on ${host}:${port} - env ${env}`);
     });
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
`process.env.API_HOST` is not avaiable on the client side but since `fetch` can work
with relative urls in this case, we can omit `API_HOST`. On the contrary,
only absolute urls are supported on the server side.